### PR TITLE
Move resume data to markdown-style JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "pdfjs-dist": "4.8.69",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-markdown": "^9.1.0",
         "react-pdf": "^9.2.1",
         "split-type": "^0.3.4",
         "tailwindcss-animate": "^1.0.7"
@@ -1315,12 +1316,38 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1329,11 +1356,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1348,6 +1389,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.33.0",
@@ -1603,6 +1650,12 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.10.0.tgz",
@@ -1769,6 +1822,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -1958,6 +2021,16 @@
         "node": "^18.12.0 || >= 20.9.0"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1973,6 +2046,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -2045,6 +2158,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2098,14 +2221,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2117,6 +2238,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
+      "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/decompress-response": {
@@ -2169,6 +2303,19 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/didyoumean": {
@@ -2464,6 +2611,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2483,6 +2640,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2898,6 +3061,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2970,6 +3183,36 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2995,6 +3238,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -3027,6 +3280,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3034,6 +3297,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3184,6 +3459,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3246,6 +3531,159 @@
         "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge-refs": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.3.0.tgz",
@@ -3271,6 +3709,448 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -3341,7 +4221,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -3545,6 +4424,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -3905,6 +4809,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -3993,6 +4907,33 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-pdf": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-9.2.1.tgz",
@@ -4056,6 +4997,39 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -4300,6 +5274,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/split-type": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/split-type/-/split-type-0.3.4.tgz",
@@ -4375,6 +5359,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -4446,6 +5444,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
+      "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.8"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
+      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/sucrase": {
@@ -4655,6 +5671,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -4676,6 +5702,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4760,6 +5796,93 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -4816,6 +5939,34 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "6.3.5",
@@ -5072,6 +6223,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "pdfjs-dist": "4.8.69",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-markdown": "^9.1.0",
     "react-pdf": "^9.2.1",
     "split-type": "^0.3.4",
     "tailwindcss-animate": "^1.0.7"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,11 +24,19 @@ export default function App() {
         const mql = window.matchMedia('print')
         const mqHandler = (e: MediaQueryListEvent) => e.matches && finish()
         // addEventListener existe no Chrome 111+, Safari 14.1+, Firefox 103+
-        mql.addEventListener?.('change', mqHandler) || mql.addListener(mqHandler)
+        if (mql.addEventListener) {
+            mql.addEventListener('change', mqHandler)
+        } else {
+            mql.addListener(mqHandler)
+        }
 
         return () => {
             window.removeEventListener('beforeprint', finish)
-            mql.removeEventListener?.('change', mqHandler) || mql.removeListener(mqHandler)
+            if (mql.removeEventListener) {
+                mql.removeEventListener('change', mqHandler)
+            } else {
+                mql.removeListener(mqHandler)
+            }
         }
     }, [])
 

--- a/src/data/resume.json
+++ b/src/data/resume.json
@@ -1,0 +1,178 @@
+{
+  "aside": {
+    "profilePicture": "perfil-picture.png",
+    "sections": [
+      {
+        "title": "Sobre Mim",
+        "paragraph": "Graduando em **Análise e Desenvolvimento de Sistemas** (UAM) e formado em **Técnico em Informática**. Dedico-me principalmente a **Java/Spring/JavaFX**, **React com TypeScript & Tailwind**, criando desde aplicações desktop a sistemas e sites completos. Sou curioso, colaborativo e sempre procuro agregar valor onde atuo, compartilhando conhecimento e, mantendo a mente aberta para novas experiências e ideias."
+      },
+      {
+        "title": "Detalhes Pessoais",
+        "list": [
+          {
+            "label": "Nome",
+            "value": "Matheus Yoshiro de Santana Bajo"
+          },
+          {
+            "label": "End.",
+            "value": "R. José Salvador Pazzobom, 345 - Jaguaribe, Osasco, SP - 06050-070"
+          },
+          {
+            "label": "Nacionalidade",
+            "value": "Brasileiro, Natural de São Paulo"
+          },
+          {
+            "label": "Estado Civil",
+            "value": "Solteiro"
+          },
+          {
+            "label": "Gênero",
+            "value": "Masculino"
+          },
+          {
+            "label": "Data de Nascimento",
+            "value": "24/01/2007"
+          }
+        ]
+      },
+      {
+        "title": "Contato",
+        "list": [
+          {
+            "label": "WhatsApp",
+            "value": "(11) 9 5413-9973",
+            "url": "https://wa.me/5511954139973"
+          },
+          {
+            "label": "E-mail",
+            "value": "matheusbajo@gmail.com",
+            "url": "mailto:matheusbajo@gmail.com"
+          },
+          {
+            "label": "Instagram",
+            "value": "@yoshiro_.bajo",
+            "url": "https://www.instagram.com/yoshiro_.bajo"
+          },
+          {
+            "label": "LinkedIn",
+            "value": "Matheus Bajo",
+            "url": "https://www.linkedin.com/in/matheusbajo"
+          },
+          {
+            "label": "GitHub",
+            "value": "MatheusBajo",
+            "url": "https://github.com/MatheusBajo"
+          }
+        ]
+      },
+      {
+        "title": "Hobbies e Interesses",
+        "paragraph": "Apaixonado por esportes: pratico **atletismo** há 6 anos e sigo uma rotina de **musculação** há 1 ano e meio, sempre alinhada a uma boa alimentação. Curto jogar **futebol** pra relaxar e manter o cárdio em dia. Nas horas livres, toco **violão há 9 anos!** Um hobby que continuo aperfeiçoando até hoje."
+      }
+    ]
+  },
+  "main": {
+    "header": {
+      "nameLines": [
+        [
+          "Matheus",
+          "Yoshiro"
+        ],
+        [
+          "de",
+          "Santana",
+          "Bajo"
+        ]
+      ],
+      "role": [
+        "Técnico",
+        "em",
+        "Informática"
+      ],
+      "contacts": [
+        {
+          "icon": "linkedin-in-brands.svg",
+          "label": "Matheus Bajo"
+        },
+        {
+          "icon": "envelope-solid.svg",
+          "label": "matheusbajo@gmail.com"
+        },
+        {
+          "icon": "whatsapp-brands.svg",
+          "label": "(11) 9 5413-9973"
+        },
+        {
+          "icon": "github-brands.svg",
+          "label": "MatheusBajo"
+        }
+      ]
+    },
+    "experiences": [
+      {
+        "code": "1.0 Canal YouTube",
+        "location": "Online",
+        "period": "2015 – 2020",
+        "title": "Criador de Conteúdo",
+        "paragraph": "Iniciei meu canal de projetos eletrônicos aos **8 anos** (2015) e atingi mais de ** 40 mil visualizações** e **900 inscritos**. Essa experiência consolidou minhas habilidades de **roteiro, gravação, edição de vídeo e comunicação**. Encerrei o canal em 2020, mas sigo usando essas técnicas em edições pontuais."
+      },
+      {
+        "code": "2.0 Locação de Games",
+        "location": "Osasco – São Paulo",
+        "period": "2019 – Presente",
+        "title": "Desenvolvedor Full Stack / Técnico de TI",
+        "paragraph": "Criei sistema de orçamentos em **JavaFX + MySQL** que reduziu o tempo de **5 min** para **~30s**, gerando até 5 propostas diferentes. Desenvolvi site responsivo em ** React TSX + Tailwind + GSAP** e configurei um ** servidor** com **Windows Server 2019** e desenvolvi um **sistema** em grupo com **Spring Boot** para melhor controle logístico e financeiro. Ofereço suporte técnico e faço manutenção diária em PCs, redes e fliperamas."
+      },
+      {
+        "code": "2.1 WeFlying",
+        "location": "Freelancer",
+        "period": "2024",
+        "title": "Desenvolvedor Front End",
+        "paragraph": "Fiz um site para a empresa de marketing **WeFlying** usando **Vite Vanilla + Tailwind**, focando em leads, performance e SEO completo."
+      },
+      {
+        "code": "2.2 Gleide Fashion Hair",
+        "location": "Osasco – São Paulo",
+        "period": "2024 – Presente",
+        "title": "Desenvolvedor Web",
+        "paragraph": "Criei landing page responsiva e dou manutenção básica em HTML, CSS e JavaScript. Auxilio em campanhas de Google Ads."
+      }
+    ],
+    "qualifications": "Desenvolvedor full stack com ênfase em **Java / Spring Boot ** no back-end e **JavaFX, React com TypeScript e Tailwind** no front-end. Experiência com **modelagem MySQL**, APIs REST e versionamento **Git / GitHub**. Conhecimento sólido em ** HTML, CSS, JavaScript/TypeScript**. Nos cursos da Alura aprofundei **orientação a objetos** (POO) **em Java**, construção de APIs REST e boas práticas de arquitetura com Spring Boot. Também atuo como gestor de tráfego com noções de **Google Ads** e **Facebook Ads**. **Investidor** ativo em **ações** desde 2020, focado em visão de longo prazo.",
+    "skills": [
+      {
+        "label": "HTML & CSS",
+        "pct": "w-[95%]"
+      },
+      {
+        "label": "Tailwind CSS",
+        "pct": "w-[95%]"
+      },
+      {
+        "label": "React & TypeScript",
+        "pct": "w-[85%]"
+      },
+      {
+        "label": "Java & Spring Boot",
+        "pct": "w-[60%]"
+      },
+      {
+        "label": "Manutenção",
+        "pct": "w-[80%]"
+      },
+      {
+        "label": "Google Ads & SEO",
+        "pct": "w-[50%]"
+      },
+      {
+        "label": "Git / GitHub",
+        "pct": "w-[40%]"
+      },
+      {
+        "label": "MySQL / SQL",
+        "pct": "w-[30%]"
+      }
+    ],
+    "footerDate": "26/05/2025"
+  }
+}

--- a/src/pages/Aside.tsx
+++ b/src/pages/Aside.tsx
@@ -2,9 +2,14 @@
 import {useEffect, useRef} from "react";
 import { gsap } from 'gsap'
 import SplitText from 'gsap/SplitText'
+import ReactMarkdown from 'react-markdown'
+import resume from '../data/resume.json'
+import type { ResumeData } from '../utils/types'
 
 export default function Aside() {
     const asideRef = useRef<HTMLElement>(null);
+    const data: ResumeData['aside'] = (resume as ResumeData).aside;
+
 
     useEffect(() => {
         if (!asideRef.current) return;
@@ -90,80 +95,52 @@ export default function Aside() {
         >
             <header className="w-full flex min-h-[220px] items-center justify-center">
                 <img
-                    src={import.meta.env.BASE_URL + "/perfil-picture.png"}
+                    src={import.meta.env.BASE_URL + data.profilePicture}
                     alt="Foto de perfil"
                     className="size-[150px] rounded-full border-[6px] border-white shadow-2xl"
                 />
             </header>
             <div className="flex flex-col gap-6 px-6 overflow-y-hidden">
-
-                {/* Sobre Mim */}
-                <section>
-                    <h2 className="">Sobre Mim</h2>
-
-                    <p className="">
-                        Graduando em <strong>Análise e Desenvolvimento de Sistemas</strong> (UAM) e formado em
-                        <strong> Técnico em Informática</strong>. Dedico-me principalmente a
-                        <strong> Java/Spring/JavaFX</strong>, <strong>React com TypeScript & Tailwind</strong>,
-                        criando desde aplicações desktop a sistemas e sites completos.
-                        Sou curioso, colaborativo e sempre procuro agregar valor onde atuo, compartilhando conhecimento
-                        e, mantendo a mente aberta
-                        para novas experiências e ideias.
-                    </p>
-                </section>
-
-
-                {/* Detalhes Pessoais */}
-                <section>
-                    <h2 className="">
-                        Detalhes Pessoais
-                    </h2>
-                    <ul className="">
-                        <li><strong>Nome:</strong> Matheus Yoshiro de Santana Bajo</li>
-                        <li><strong>End.:</strong> R. José Salvador Pazzobom, 345 - Jaguaribe, Osasco, SP - 06050-070
-                        </li>
-                        <li><strong>Nacionalidade:</strong> Brasileiro, Natural de São Paulo</li>
-                        <li><strong>Estado Civil:</strong> Solteiro</li>
-                        <li><strong>Gênero:</strong> Masculino</li>
-                        <li><strong>Data de Nascimento:</strong> 24/01/2007</li>
-                    </ul>
-                </section>
-
-                {/*Contato*/}
-                <section>
-                    <h2 className="">
-                        Contato
-                    </h2>
-                    <ul>
-                        <li><strong>WhatsApp:</strong> <a
-                            className="underline print:no-underline text-blue-300 print:text-white/90"
-                            href="https://wa.me/5511954139973" target="_blank">(11) 9 5413-9973</a></li>
-                        <li><strong>E-mail:</strong> <a
-                            className="underline print:no-underline text-blue-300 print:text-white/90"
-                            href="mailto:matheusbajo@gmail.com">matheusbajo@gmail.com</a></li>
-                        <li><strong>Instagram:</strong> <a
-                            className="underline print:no-underline text-blue-300 print:text-white/90"
-                            href="https://www.instagram.com/yoshiro_.bajo" target="_blank">@yoshiro_.bajo</a></li>
-                        <li><strong>LinkedIn:</strong> <a
-                            className="underline print:no-underline text-blue-300 print:text-white/90"
-                            href="https://www.linkedin.com/in/matheusbajo" target="_blank">Matheus Bajo</a></li>
-                        <li><strong>GitHub:</strong> <a
-                            className="underline print:no-underline text-blue-300 print:text-white/90"
-                            href="https://github.com/MatheusBajo" target="_blank">MatheusBajo</a></li>
-                    </ul>
-                </section>
-
-                {/* Hobbies e Interesses */}
-                <section>
-                    <h2 className="text-lg font-extrabold uppercase">Hobbies e Interesses</h2>
-
-                    <p className="text-[9pt] font-medium leading-snug text-justify">
-                        Apaixonado por esportes: pratico <strong>atletismo</strong> há 6&nbsp;anos e sigo uma rotina de
-                        <strong> musculação</strong> há 1&nbsp;ano e meio, sempre alinhada a uma boa alimentação.
-                        Curto jogar <strong>futebol</strong> pra relaxar e manter o cárdio em dia. Nas horas livres,
-                        toco <strong>violão há 9&nbsp;anos!</strong> Um hobby que continuo aperfeiçoando até hoje.
-                    </p>
-                </section>
+                {data.sections.map(sec => (
+                    <section key={sec.title}>
+                        <h2 className={sec.title === 'Hobbies e Interesses' ? 'text-lg font-extrabold uppercase' : ''}>{sec.title}</h2>
+                        {sec.paragraph && (
+                            <ReactMarkdown
+                                components={{
+                                    p: ({...props}) => (
+                                        <p
+                                            className={sec.title === 'Hobbies e Interesses' ? 'text-[9pt] font-medium leading-snug text-justify' : ''}
+                                            {...props}
+                                        />
+                                    ),
+                                    strong: ({...props}) => <strong className="font-bold" {...props} />,
+                                }}
+                            >
+                                {sec.paragraph}
+                            </ReactMarkdown>
+                        )}
+                        {sec.list && (
+                            <ul className="">
+                                {sec.list.map(item => (
+                                    <li key={item.label}>
+                                        <strong>{item.label}:</strong>{' '}
+                                        {item.url ? (
+                                            <a
+                                                className="underline print:no-underline text-blue-300 print:text-white/90"
+                                                href={item.url}
+                                                target="_blank"
+                                            >
+                                                {item.value}
+                                            </a>
+                                        ) : (
+                                            item.value
+                                        )}
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </section>
+                ))}
 
 
             </div>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -2,9 +2,14 @@
 import gsap from "gsap";
 import { SplitText } from "gsap/SplitText";
 import {useEffect, useRef} from "react";
+import ReactMarkdown from 'react-markdown'
+import resume from '../data/resume.json'
+import type { ResumeData } from '../utils/types'
 
 export default function Main() {
     const mainRef = useRef<HTMLElement>(null);
+    const data: ResumeData['main'] = (resume as ResumeData).main;
+
 
     useEffect(() => {
         if (!mainRef.current) return;
@@ -140,53 +145,31 @@ export default function Main() {
                 <div className="flex flex-grow items-center justify-between ">
                     <div className="flex flex-col items-start justify-center">
                         <h1 className="font-extrabold uppercase w-full text-foreground leading-[1.25]">
-                            <div className="flex justify-between w-full text-[18.85pt] gap-3">
-                                <span>Matheus</span>
-                                <span>Yoshiro</span>
-                            </div>
-                            <div className="flex justify-between w-full text-[18.85pt]">
-                                <span>de</span>
-                                <span>Santana</span>
-                                <span>Bajo</span>
-                            </div>
+                            {data.header.nameLines.map((line, i) => (
+                                <div key={i} className={`flex justify-between w-full text-[18.85pt]${i === 0 ? ' gap-3' : ''}`}> 
+                                    {line.map(part => (
+                                        <span key={part}>{part}</span>
+                                    ))}
+                                </div>
+                            ))}
                         </h1>
 
                         <p className="flex justify-between w-full text-[16pt] leading-[1] tracking-tight font-thin uppercase">
-                            <span>Técnico</span>
-                            <span>em</span>
-                            <span>Informática</span>
+                            {data.header.role.map(r => (
+                                <span key={r}>{r}</span>
+                            ))}
                         </p>
 
                     </div>
                     <ul className="flex flex-col h-full divide-y-[1px] divide-background">
-                        <li className="flex-1 flex items-center gap-2">
-                            <span
-                                className="inline-flex items-center justify-center size-[14px] bg-background rounded-[2px]">
-                              <img src={import.meta.env.BASE_URL + "/linkedin-in-brands.svg"} alt="LinkedIn" className="px-[3px] invert"/>
-                            </span>
-                            <span className="text-[10pt] font-bold">Matheus Bajo</span>
-                        </li>
-                        <li className="flex-1 flex items-center gap-2">
-                            <span
-                                className="inline-flex items-center justify-center size-[14px] bg-background rounded-[2px]">
-                              <img src={import.meta.env.BASE_URL + "/envelope-solid.svg"} alt="Email" className="px-[3px] invert"/>
-                            </span>
-                            <span className="text-[10pt] font-bold">matheusbajo@gmail.com</span>
-                        </li>
-                        <li className="flex-1 flex items-center gap-2">
-                            <span
-                                className="inline-flex items-center justify-center size-[14px] bg-background rounded-[2px]">
-                              <img src={import.meta.env.BASE_URL + "/whatsapp-brands.svg"} alt="WhatsApp" className="px-[3px] invert"/>
-                            </span>
-                            <span className="text-[10pt] font-bold">(11) 9 5413-9973</span>
-                        </li>
-                        <li className="flex-1 flex items-center gap-2">
-                            <span
-                                className="inline-flex items-center justify-center size-[14px] bg-background rounded-[2px]">
-                              <img src={import.meta.env.BASE_URL + "/github-brands.svg"} alt="Instagram" className="px-[3px] invert"/>
-                            </span>
-                            <span className="text-[10pt] font-bold">MatheusBajo</span>
-                        </li>
+                        {data.header.contacts.map(c => (
+                            <li key={c.label} className="flex-1 flex items-center gap-2">
+                                <span className="inline-flex items-center justify-center size-[14px] bg-background rounded-[2px]">
+                                    <img src={import.meta.env.BASE_URL + '/' + c.icon} alt={c.label} className="px-[3px] invert" />
+                                </span>
+                                <span className="text-[10pt] font-bold">{c.label}</span>
+                            </li>
+                        ))}
                     </ul>
                 </div>
 
@@ -198,90 +181,31 @@ export default function Main() {
                 <h2 className="">Experiência Profissional</h2>
 
                 <div className="space-y-4">
-                    {/* 1.0 YouTube */}
-                    <div className="flex job-row">
-                        <div className="w-1/4 text-left pr-2 job-left">
-                            <p className="text-sm font-bold text-gray-600 uppercase">1.0 Canal YouTube</p>
-                            <p className="text-xs text-gray-500">Online</p>
-                            <p className="text-xs text-gray-500">2015 – 2020</p>
-                        </div>
-                        <div className="w-3/4 pl-6 border-l-2 border-gray-200 section-exp">
+                    {data.experiences.map(exp => (
+                        <div className="flex job-row" key={exp.code}>
+                            <div className="w-1/4 text-left pr-2 job-left">
+                                <p className="text-sm font-bold text-gray-600 uppercase">{exp.code}</p>
+                                <p className="text-xs text-gray-500">{exp.location}</p>
+                                <p className="text-xs text-gray-500">{exp.period}</p>
+                            </div>
+                            <div className="w-3/4 pl-6 border-l-2 border-gray-200 section-exp">
 
-                            <h3 className="font-bold uppercase leading-[1] mb-2">
-                                Criador de Conteúdo
-                            </h3>
-                            <p className="text-justify font-normal text-[9pt] leading-[1.25]">
-                                Iniciei meu canal de projetos eletrônicos aos <strong>8 anos</strong> (2015) e atingi
-                                mais de
-                                <strong> 40 mil visualizações</strong> e <strong>900 inscritos</strong>. Essa
-                                experiência consolidou minhas
-                                habilidades de <strong>roteiro, gravação, edição de vídeo e comunicação</strong>.
-                                Encerrei o canal em 2020,
-                                mas sigo usando essas técnicas em edições pontuais.
-                            </p>
-
+                                <h3 className="font-bold uppercase leading-[1] mb-2">
+                                    {exp.title}
+                                </h3>
+                                <ReactMarkdown
+                                    components={{
+                                        p: ({...props}) => (
+                                            <p className="text-justify font-normal text-[9pt] leading-[1.25]" {...props} />
+                                        ),
+                                        strong: ({...props}) => <strong className="font-bold" {...props} />,
+                                    }}
+                                >
+                                    {exp.paragraph}
+                                </ReactMarkdown>
+                            </div>
                         </div>
-                    </div>
-
-                    {/* 2.0 Locação de Games */}
-                    <div className="flex job-row">
-                        <div className="w-1/4 text-left pr-2 job-left">
-                            <p className="text-sm font-bold text-gray-600 uppercase">2.0 Locação de Games</p>
-                            <p className="text-xs text-gray-500">Osasco – São Paulo</p>
-                            <p className="text-xs text-gray-500">2019 – Presente</p>
-                        </div>
-                        <div className="w-3/4 pl-6 border-l-2 border-gray-200 section-exp">
-
-                            <h3 className="font-bold uppercase leading-[1] mb-2 whitespace-nowrap">
-                                Desenvolvedor Full Stack / Técnico de TI
-                            </h3>
-                            <p className="text-justify font-normal text-[9pt] leading-[1.25]">
-                                Criei sistema de orçamentos em <strong>JavaFX + MySQL</strong> que
-                                reduziu o tempo de <strong>5 min</strong> para <strong>~30s</strong>, gerando até 5 propostas diferentes. Desenvolvi site responsivo em
-                                <strong> React TSX + Tailwind + GSAP</strong> e configurei um
-                                <strong> servidor</strong> com <strong>Windows Server 2019</strong> e desenvolvi um <strong>sistema</strong> em grupo com <strong>Spring Boot</strong> para melhor controle logístico e
-                                financeiro. Ofereço suporte técnico e faço manutenção diária em PCs,
-                                redes e fliperamas.
-                            </p>
-                        </div>
-                    </div>
-
-                    {/* 2.1 WeFlying Marketing */}
-                    <div className="flex job-row">
-                        <div className="w-1/4 text-left pr-2 job-left">
-                            <p className="text-sm font-bold text-gray-600 uppercase">2.1 WeFlying</p>
-                            <p className="text-xs text-gray-500">Freelancer</p>
-                            <p className="text-xs text-gray-500">2024</p>
-                        </div>
-                        <div className="w-3/4 pl-6 border-l-2 border-gray-200 section-exp">
-
-                            <h3 className="font-bold uppercase leading-[1] mb-2">
-                                Desenvolvedor Front End
-                            </h3>
-                            <p className="text-justify font-normal text-[9pt] leading-[1.25]">
-                                Fiz um site para a empresa de marketing <strong>WeFlying</strong> usando <strong>Vite Vanilla + Tailwind</strong>,
-                                focando em leads, performance e SEO completo.
-                            </p>
-                        </div>
-                    </div>
-
-                    {/* 2.2 Gleide Fashion Hair */}
-                    <div className="flex job-row">
-                        <div className="w-1/4 text-left pr-2 job-left">
-                            <p className="text-sm font-bold text-gray-600 uppercase">2.2 Gleide Fashion Hair</p>
-                            <p className="text-xs text-gray-500">Osasco – São Paulo</p>
-                            <p className="text-xs text-gray-500">2024 – Presente</p>
-                        </div>
-                        <div className="w-3/4 pl-6 border-l-2 border-gray-200 section-exp">
-
-                            <h3 className="font-bold uppercase leading-[1] mb-2">
-                                Desenvolvedor Web
-                            </h3>
-                            <p className="text-justify font-normal text-[9pt] leading-[1.25]">
-                                Criei landing page responsiva e dou manutenção básica em HTML, CSS e JavaScript. Auxilio em campanhas de Google Ads.
-                            </p>
-                        </div>
-                    </div>
+                    ))}
                 </div>
             </section>
 
@@ -293,22 +217,20 @@ export default function Main() {
                     QUALIFICAÇÕES
                 </h2>
 
-                <p className="text-justify font-normal text-[9pt] leading-[1.25]">
-                    Desenvolvedor full stack com ênfase em <strong>Java / Spring Boot </strong>
-                    no back-end e <strong>JavaFX, React com TypeScript e Tailwind</strong> no
-                    front-end. Experiência com <strong>modelagem MySQL</strong>, APIs REST e
-                    versionamento <strong>Git / GitHub</strong>. Conhecimento sólido em
-                    <strong> HTML, CSS, JavaScript/TypeScript</strong>. Nos cursos da Alura
-                    aprofundei <strong>orientação a objetos</strong> (POO) <strong>em Java</strong>, construção de APIs REST e boas
-                    práticas de arquitetura com Spring Boot. Também atuo como gestor de tráfego
-                    com noções de <strong>Google Ads</strong> e <strong>Facebook Ads</strong>.
-                    <strong> Investidor</strong> ativo em <strong>ações</strong> desde 2020, focado em visão de longo prazo.
-                </p>
+                <ReactMarkdown
+                    components={{
+                        p: ({...props}) => (
+                            <p className="text-justify font-normal text-[9pt] leading-[1.25]" {...props} />
+                        ),
+                        strong: ({...props}) => <strong className="font-bold" {...props} />,
+                    }}
+                >
+                    {data.qualifications}
+                </ReactMarkdown>
 
             </section>
 
 
-            {/* Competências */}
             {/* Competências */}
             <section className="mb-8">
                 <h2 className="text-[16pt] font-bold border-b-2 border-background mb-4 uppercase">
@@ -316,16 +238,7 @@ export default function Main() {
                 </h2>
 
                 <div className="grid grid-cols-2 gap-x-12 gap-y-2 text-[8pt] font-bold">
-                    {[
-                        { label: 'HTML & CSS', pct: 'w-[95%]' },
-                        { label: 'Tailwind CSS', pct: 'w-[95%]' },
-                        { label: 'React & TypeScript', pct: 'w-[85%]' },
-                        { label: 'Java & Spring Boot', pct: 'w-[60%]' },
-                        { label: 'Manutenção', pct: 'w-[80%]' },
-                        { label: 'Google Ads & SEO', pct: 'w-[50%]' },
-                        { label: 'Git / GitHub', pct: 'w-[40%]' },
-                        { label: 'MySQL / SQL', pct: 'w-[30%]' },
-                    ].map(({ label, pct }) => (
+                    {data.skills.map(({ label, pct }) => (
                         <div key={label} className="flex items-center gap-4">
                             <span className="text-gray-800 font-medium min-w-[110px]">{label}</span>
                             <div className="flex-1 h-2 bg-[#dcdcdc] rounded-full overflow-hidden">
@@ -340,7 +253,7 @@ export default function Main() {
 
             <footer className="flex mx-auto h-full items-end p-1">
                 <div className="relative b-0 text-center text-gray-500 text-[6pt] mt-4">
-                    <p>Currículo atualizado em: 26/05/2025</p>
+                    <p>Currículo atualizado em: {data.footerDate}</p>
                     <p>Desenvolvido por Matheus Bajo</p>
                 </div>
             </footer>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,46 @@
+export interface ListItem {
+    label: string;
+    value: string;
+    url?: string;
+}
+
+export interface Section {
+    title: string;
+    paragraph?: string;
+    list?: ListItem[];
+}
+
+export interface AsideData {
+    profilePicture: string;
+    sections: Section[];
+}
+
+export interface HeaderData {
+    nameLines: string[][];
+    role: string[];
+    contacts: {
+        icon: string;
+        label: string;
+    }[];
+}
+
+export interface Experience {
+    code: string;
+    location: string;
+    period: string;
+    title: string;
+    paragraph: string;
+}
+
+export interface MainData {
+    header: HeaderData;
+    experiences: Experience[];
+    qualifications: string;
+    skills: { label: string; pct: string }[];
+    footerDate: string;
+}
+
+export interface ResumeData {
+    aside: AsideData;
+    main: MainData;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- store resume text as markdown strings in `resume.json`
- parse markdown in `Aside` and `Main` via `react-markdown`
- update TypeScript interfaces
- add `react-markdown` dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68470409b8048331890b2144d12b6489