### PR TITLE
Add clean and secure resume modes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,14 @@ import { PAGE_W, PAGE_H } from './utils/pageConstants';
 import FittedPdf from './FittedPdf';
 import { CERTIFICADOS } from './utils/certificates';
 import './utils/pdfWorker';
-import {useEffect} from "react";          // mantém o worker
+import {useEffect, useState} from "react";          // mantém o worker
 import { gsap } from 'gsap'          // coloque no topo de TODO arquivo que use gsap
+import CleanResume from './pages/CleanResume';
+import type { Variant } from './pages/Aside';
 
 
 export default function App() {
+    const [variant, setVariant] = useState<Variant>('secure');
 
     useEffect(() => {
         // empurra tudo pro fim e força repaint síncrono
@@ -43,31 +46,40 @@ export default function App() {
 
     return (
         <main className="flex flex-col gap-2 print:gap-0">
+            <div className="fixed top-2 right-2 z-50 flex gap-2">
+                <button onClick={() => setVariant('clean')} className="px-2 py-1 bg-white text-black border">Clean</button>
+                <button onClick={() => setVariant('secure')} className="px-2 py-1 bg-white text-black border">Segura</button>
+            </div>
+
             {/* Currículo */}
-            <section
-                className="flex justify-center items-stretch
+            {variant === 'clean' ? (
+                <CleanResume />
+            ) : (
+                <section
+                    className="flex justify-center items-stretch
                    w-full md:w-dvw
                    h-auto   md:h-dvh
                    max-w-100dvw max-h-dvh
                    print:break-after-page"
-            >
-                <svg
-                    /* largura sempre 100%; altura só cresce acima de md */
-                    className="w-full h-auto md:h-full"
-                    viewBox={`0 0 ${PAGE_W} ${PAGE_H}`}
-                    preserveAspectRatio="xMidYMid meet"
                 >
-                    <foreignObject x="0" y="0" width={PAGE_W} height={PAGE_H}>
-                        <div
-                            xmlns="http://www.w3.org/1999/xhtml"
-                            className="page flex w-full h-full bg-white"
-                        >
-                            <Aside />
-                            <Main />
-                        </div>
-                    </foreignObject>
-                </svg>
-            </section>
+                    <svg
+                        /* largura sempre 100%; altura só cresce acima de md */
+                        className="w-full h-auto md:h-full"
+                        viewBox={`0 0 ${PAGE_W} ${PAGE_H}`}
+                        preserveAspectRatio="xMidYMid meet"
+                    >
+                        <foreignObject x="0" y="0" width={PAGE_W} height={PAGE_H}>
+                            <div
+                                xmlns="http://www.w3.org/1999/xhtml"
+                                className="page flex w-full h-full bg-white"
+                            >
+                                <Aside variant={variant} />
+                                <Main variant={variant} />
+                            </div>
+                        </foreignObject>
+                    </svg>
+                </section>
+            )}
 
             {/* Certificados */}
             {CERTIFICADOS.map(cert => (

--- a/src/pages/Aside.tsx
+++ b/src/pages/Aside.tsx
@@ -6,7 +6,8 @@ import ReactMarkdown from 'react-markdown'
 import resume from '../data/resume.json'
 import type { ResumeData } from '../utils/types'
 
-export default function Aside() {
+export type Variant = 'secure' | 'clean';
+export default function Aside({ variant }: { variant: Variant }) {
     const asideRef = useRef<HTMLElement>(null);
     const data: ResumeData['aside'] = (resume as ResumeData).aside;
 
@@ -93,16 +94,22 @@ export default function Aside() {
             ref={asideRef}
             className="w-[30%] bg-[#1a2e35] flex flex-col items-center overflow-visible"
         >
-            <header className="w-full flex min-h-[220px] items-center justify-center">
-                <img
-                    src={import.meta.env.BASE_URL + data.profilePicture}
-                    alt="Foto de perfil"
-                    className="size-[150px] rounded-full border-[6px] border-white shadow-2xl"
-                />
-            </header>
+            {variant === 'secure' && (
+                <header className="w-full flex min-h-[220px] items-center justify-center">
+                    <img
+                        src={import.meta.env.BASE_URL + data.profilePicture}
+                        alt="Foto de perfil"
+                        className="size-[150px] rounded-full border-[6px] border-white shadow-2xl"
+                    />
+                </header>
+            )}
             <div className="flex flex-col gap-6 px-6 overflow-y-hidden">
-                {data.sections.map(sec => (
-                    <section key={sec.title}>
+                {data.sections.map(sec => {
+                    if (variant === 'secure' && sec.title === 'Contato' && sec.list) {
+                        sec = { ...sec, list: sec.list.filter(item => item.label !== 'WhatsApp') };
+                    }
+                    return (
+                        <section key={sec.title}>
                         <h2 className={sec.title === 'Hobbies e Interesses' ? 'text-lg font-extrabold uppercase' : ''}>{sec.title}</h2>
                         {sec.paragraph && (
                             <ReactMarkdown

--- a/src/pages/CleanResume.tsx
+++ b/src/pages/CleanResume.tsx
@@ -1,0 +1,70 @@
+import resume from '../data/resume.json'
+import type { ResumeData } from '../utils/types'
+import { CERTIFICADOS } from '../utils/certificates'
+
+export default function CleanResume() {
+    const data = resume as ResumeData
+    const personal = data.aside.sections.find(s => s.title === 'Detalhes Pessoais')
+    const contact = data.aside.sections.find(s => s.title === 'Contato')
+    const summary = data.aside.sections.find(s => s.title === 'Sobre Mim')
+
+    return (
+        <article className="w-[210mm] mx-auto p-6 font-sans text-black text-[10pt]">
+            <header className="mb-4">
+                <h1 className="text-[14pt] font-bold">
+                    {data.main.header.nameLines.flat().join(' ')}
+                </h1>
+                <p className="text-[12pt]">{data.main.header.role.join(' ')}</p>
+                <ul className="text-[10pt]">
+                    {personal?.list?.map(item => (
+                        <li key={item.label}><strong>{item.label}:</strong> {item.value}</li>
+                    ))}
+                    {contact?.list?.filter(i => i.label !== 'WhatsApp').map(item => (
+                        <li key={item.label}><strong>{item.label}:</strong> {item.value}</li>
+                    ))}
+                </ul>
+            </header>
+
+            {summary && (
+                <section className="mb-4">
+                    <h2 className="text-[12pt] font-bold">Resumo Profissional</h2>
+                    <p>{summary.paragraph}</p>
+                </section>
+            )}
+
+            <section className="mb-4">
+                <h2 className="text-[12pt] font-bold">Competências Técnicas</h2>
+                <ul className="list-disc pl-4">
+                    {data.main.skills.map(s => (
+                        <li key={s.label}>{s.label}</li>
+                    ))}
+                </ul>
+            </section>
+
+            <section className="mb-4">
+                <h2 className="text-[12pt] font-bold">Experiência Profissional</h2>
+                {data.main.experiences.slice(0,4).map(exp => (
+                    <div key={exp.code} className="mb-2">
+                        <p className="font-bold">{exp.title} - {exp.code}</p>
+                        <p className="italic">{exp.period} | {exp.location}</p>
+                        <p>{exp.paragraph}</p>
+                    </div>
+                ))}
+            </section>
+
+            <section className="mb-4">
+                <h2 className="text-[12pt] font-bold">Projetos ou Certificações</h2>
+                <ul className="list-disc pl-4">
+                    {CERTIFICADOS.map(c => (
+                        <li key={c.src}>{c.titulo}</li>
+                    ))}
+                </ul>
+            </section>
+
+            <section className="mb-4">
+                <h2 className="text-[12pt] font-bold">Idiomas</h2>
+                <p>Português (nativo)</p>
+            </section>
+        </article>
+    )
+}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -5,10 +5,15 @@ import {useEffect, useRef} from "react";
 import ReactMarkdown from 'react-markdown'
 import resume from '../data/resume.json'
 import type { ResumeData } from '../utils/types'
+import type { Variant } from './Aside'
 
-export default function Main() {
+export default function Main({ variant }: { variant: Variant }) {
     const mainRef = useRef<HTMLElement>(null);
     const data: ResumeData['main'] = (resume as ResumeData).main;
+    const header = { ...data.header };
+    if (variant === 'secure') {
+        header.contacts = header.contacts.filter(c => !c.label.includes('95413'));
+    }
 
 
     useEffect(() => {
@@ -145,7 +150,7 @@ export default function Main() {
                 <div className="flex flex-grow items-center justify-between ">
                     <div className="flex flex-col items-start justify-center">
                         <h1 className="font-extrabold uppercase w-full text-foreground leading-[1.25]">
-                            {data.header.nameLines.map((line, i) => (
+                            {header.nameLines.map((line, i) => (
                                 <div key={i} className={`flex justify-between w-full text-[18.85pt]${i === 0 ? ' gap-3' : ''}`}> 
                                     {line.map(part => (
                                         <span key={part}>{part}</span>
@@ -155,14 +160,14 @@ export default function Main() {
                         </h1>
 
                         <p className="flex justify-between w-full text-[16pt] leading-[1] tracking-tight font-thin uppercase">
-                            {data.header.role.map(r => (
+                            {header.role.map(r => (
                                 <span key={r}>{r}</span>
                             ))}
                         </p>
 
                     </div>
                     <ul className="flex flex-col h-full divide-y-[1px] divide-background">
-                        {data.header.contacts.map(c => (
+                        {header.contacts.map(c => (
                             <li key={c.label} className="flex-1 flex items-center gap-2">
                                 <span className="inline-flex items-center justify-center size-[14px] bg-background rounded-[2px]">
                                     <img src={import.meta.env.BASE_URL + '/' + c.icon} alt={c.label} className="px-[3px] invert" />


### PR DESCRIPTION
## Summary
- add CleanResume page for ATS-friendly layout
- hide picture and WhatsApp info in secure mode
- toggle between Clean and Segura via fixed buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68489e898d408331a256f5cfb5cf2a70