### PR TITLE
Add toggle for clean resume layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,14 @@ import { PAGE_W, PAGE_H } from './utils/pageConstants';
 import FittedPdf from './FittedPdf';
 import { CERTIFICADOS } from './utils/certificates';
 import './utils/pdfWorker';
-import {useEffect} from "react";          // mantém o worker
+import {useEffect, useState} from "react";          // mantém o worker
 import { gsap } from 'gsap'          // coloque no topo de TODO arquivo que use gsap
+import Button from './components/ui/button';
+import CleanResume from './pages/CleanResume';
 
 
 export default function App() {
+    const [clean, setClean] = useState(false);
 
     useEffect(() => {
         // empurra tudo pro fim e força repaint síncrono
@@ -43,7 +46,16 @@ export default function App() {
 
     return (
         <main className="flex flex-col gap-2 print:gap-0">
+            <div className="fixed top-2 right-2 z-50">
+                <Button variant="outline" onClick={() => setClean(c => !c)}>
+                    {clean ? 'Voltar ao layout original' : 'Versão Clean'}
+                </Button>
+            </div>
+
             {/* Currículo */}
+            {clean ? (
+                <CleanResume />
+            ) : (
             <section
                 className="flex justify-center items-stretch
                    w-full md:w-dvw
@@ -68,6 +80,7 @@ export default function App() {
                     </foreignObject>
                 </svg>
             </section>
+            )}
 
             {/* Certificados */}
             {CERTIFICADOS.map(cert => (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,22 @@
+import type { ButtonHTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'default' | 'outline';
+};
+
+export default function Button({
+  className,
+  variant = 'default',
+  ...props
+}: ButtonProps) {
+  const base =
+    'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+  const variants =
+    variant === 'outline'
+      ? 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
+      : 'bg-primary text-primary-foreground hover:bg-primary/90';
+  return (
+    <button className={cn(base, variants, className)} {...props} />
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | false | null | undefined)[]) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/src/pages/CleanResume.tsx
+++ b/src/pages/CleanResume.tsx
@@ -1,0 +1,70 @@
+import resume from '../data/resume.json'
+import type { ResumeData } from '../utils/types'
+import { CERTIFICADOS } from '../utils/certificates'
+
+export default function CleanResume() {
+    const data = resume as ResumeData
+    const personal = data.aside.sections.find(s => s.title === 'Detalhes Pessoais')
+    const contact = data.aside.sections.find(s => s.title === 'Contato')
+    const summary = data.aside.sections.find(s => s.title === 'Sobre Mim')
+
+    return (
+        <article className="w-[210mm] mx-auto p-6 font-sans text-black text-[10pt]">
+            <header className="mb-4">
+                <h1 className="text-[14pt] font-bold">
+                    {data.main.header.nameLines.flat().join(' ')}
+                </h1>
+                <p className="text-[12pt]">{data.main.header.role.join(' ')}</p>
+                <ul className="text-[10pt]">
+                    {personal?.list?.map(item => (
+                        <li key={item.label}><strong>{item.label}:</strong> {item.value}</li>
+                    ))}
+                    {contact?.list?.filter(i => i.label !== 'WhatsApp').map(item => (
+                        <li key={item.label}><strong>{item.label}:</strong> {item.value}</li>
+                    ))}
+                </ul>
+            </header>
+
+            {summary && (
+                <section className="mb-4">
+                    <h2 className="text-[12pt] font-bold">Resumo Profissional</h2>
+                    <p>{summary.paragraph}</p>
+                </section>
+            )}
+
+            <section className="mb-4">
+                <h2 className="text-[12pt] font-bold">Competências Técnicas</h2>
+                <ul className="list-disc pl-4">
+                    {data.main.skills.map(s => (
+                        <li key={s.label}>{s.label}</li>
+                    ))}
+                </ul>
+            </section>
+
+            <section className="mb-4">
+                <h2 className="text-[12pt] font-bold">Experiência Profissional</h2>
+                {data.main.experiences.slice(0,4).map(exp => (
+                    <div key={exp.code} className="mb-2">
+                        <p className="font-bold">{exp.title} - {exp.code}</p>
+                        <p className="italic">{exp.period} | {exp.location}</p>
+                        <p>{exp.paragraph}</p>
+                    </div>
+                ))}
+            </section>
+
+            <section className="mb-4">
+                <h2 className="text-[12pt] font-bold">Projetos ou Certificações</h2>
+                <ul className="list-disc pl-4">
+                    {CERTIFICADOS.map(c => (
+                        <li key={c.src}>{c.titulo}</li>
+                    ))}
+                </ul>
+            </section>
+
+            <section className="mb-4">
+                <h2 className="text-[12pt] font-bold">Idiomas</h2>
+                <p>Português (nativo)</p>
+            </section>
+        </article>
+    )
+}


### PR DESCRIPTION
## Resumo
- adiciona utilitário simples `cn` e componente `Botao` com classes no estilo shadcn
- restaura a página `CleanResume`
- adiciona botão de alternância em `App` para trocar entre currículo original e versão limpa